### PR TITLE
Allow `use StructFields` to be placed anywhere at top level

### DIFF
--- a/lib/struct_fields.ex
+++ b/lib/struct_fields.ex
@@ -16,7 +16,12 @@ defmodule StructFields do
   """
 
   @doc false
-  defmacro __using__(_) do
+  defmacro __using__(_opts) do
+    quote do
+      @before_compile StructFields
+    end
+  end
+  defmacro __before_compile__(_env) do
     quote do
       def fields do
         Map.keys(%__MODULE__{}) |> List.delete(:__struct__)

--- a/test/struct_fields_test.exs
+++ b/test/struct_fields_test.exs
@@ -12,4 +12,16 @@ defmodule StructFieldsTest do
     assert Enum.member?(MyModule.fields, :foo)
     assert Enum.member?(MyModule.fields, :bar)
   end
+
+  test "use declared anywhere at top level" do
+    defmodule MyModule do
+      use StructFields
+
+      defstruct greeting: :hello
+      def greet(%MyModule{greeting: g}), do: g
+    end
+
+    assert length(MyModule.fields) == 1
+    assert Enum.member?(MyModule.fields, :greeting)
+  end
 end

--- a/test/struct_fields_test.exs
+++ b/test/struct_fields_test.exs
@@ -14,14 +14,14 @@ defmodule StructFieldsTest do
   end
 
   test "use declared anywhere at top level" do
-    defmodule MyModule do
+    defmodule TestGreeter do
       use StructFields
 
       defstruct greeting: :hello
-      def greet(%MyModule{greeting: g}), do: g
+      def greet(%TestGreeter{greeting: g}), do: g
     end
 
-    assert length(MyModule.fields) == 1
-    assert Enum.member?(MyModule.fields, :greeting)
+    assert length(TestGreeter.fields) == 1
+    assert Enum.member?(TestGreeter.fields, :greeting)
   end
 end


### PR DESCRIPTION
Hello, 
I like the direction this library is headed, letting Modules become a powerful way to have the code tell you about itself.

In the style that my team has been using for developing in elixir, we like to put uses above our defs. This is just personal preference, and probably is just because we like seeing what a module is as part of a signature.

So, when using struct_fields, we couldn't write something like:

<pre><code>
defmodule MyModule do
  use StructFields
  use SomethingElse
  import YouSeeWhereIm.Going
  defstruct [:foo, :bar]
end
</code></pre>


because the macro `%__MODULE__{}` is invalid for modules that do not yet have structs and is expanded at compile time (when fields is defined) not when fields is called.

So this PR just moves that logic to a before_compile, to ensure that `defstruct` is defined before `%__MODULE__{}` is invoked and adds a test case showing it works for `use StructFields` placed before `defstruct`. 

Thanks!
