### PR TITLE
Add `ignore` option for `use StructFields`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [unreleased]
+- Add `ignore` option to exclude fields
+
 ## [0.2.0] - 2016-02-07
 - Allow `use StructFields` to be placed above struct definition
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,13 @@ Tiny module to easily get a list of fields for structs.
 
 ```elixir
 defmodule MyModule do
-  defstruct [:foo, :bar]
-
-  # Use the module
   use StructFields
+
+  defstruct [:foo, :bar]
 end
 
 MyModule.fields
-#=> [:foo, :bar]
+#=> [:bar, :foo]
 ```
 
 ## Installation

--- a/test/struct_fields_test.exs
+++ b/test/struct_fields_test.exs
@@ -1,27 +1,24 @@
 defmodule StructFieldsTest do
   use ExUnit.Case
+  doctest StructFields
 
   test "fields" do
     defmodule MyModule do
-      defstruct [:foo, :bar]
-
       use StructFields
+
+      defstruct [:foo, :bar]
     end
 
-    assert length(MyModule.fields) == 2
-    assert Enum.member?(MyModule.fields, :foo)
-    assert Enum.member?(MyModule.fields, :bar)
+    assert MyModule.fields == [:bar, :foo]
   end
 
-  test "use declared anywhere at top level" do
-    defmodule TestGreeter do
-      use StructFields
+  test "ignore option" do
+    defmodule MyModuleIgnoreFields do
+      use StructFields, ignore: [:foo]
 
-      defstruct greeting: :hello
-      def greet(%TestGreeter{greeting: g}), do: g
+      defstruct [:foo, :bar, :baz]
     end
 
-    assert length(TestGreeter.fields) == 1
-    assert Enum.member?(TestGreeter.fields, :greeting)
+    assert MyModuleIgnoreFields.fields == [:bar, :baz]
   end
 end


### PR DESCRIPTION
Also:
- Clean up documentation
- Clean up tests
- Use doctest
- Improve performance (have final list at compile time)

This PR addresses the suggestion made by #1.

---

Some explanation of what I did here.
#### Calculation of final list in module attribute

``` elixir
@fields Map.keys(%__MODULE__{}) -- @fields_to_ignore

def fields, do: @fields
```

Previously the `fields` function had still some unnecessary computation after compilation (`|> List.delete(:__struct__)`). Since the struct and therefore the fields do not change after compilation, we can define functions by just returning the final value.

While here it might not be the biggest performance issue, this pattern can save you a lot in some circumstances (tight loops with repeated calls to such functions).
#### Module attribute juggling

Since we use `@before_compile`, which does not allow to directly pass values, we need to utilize the fact, that the module itself is not compiled yet, which allows us to define more attributes to be used later on.
While we are in the `StructFields` module, we need to define those attributes for our target module via [`Module.put_attribute/3`](http://elixir-lang.org/docs/stable/elixir/Module.html#put_attribute/3).

Btw `quote bind_quoted: […]` is a pretty convenient way to pass values into the quote block, where you normally would have to do `unquote(…)` instead. ([Kernel.SpecialForms.quote/2](http://elixir-lang.org/docs/stable/elixir/Kernel.SpecialForms.html#quote/2))
#### doctest

If you have code samples in your module documentation it always make sense to consider them as test cases. Therefore this PR introduces [`doctest`](http://elixir-lang.org/docs/stable/ex_unit/ExUnit.DocTest.html).
